### PR TITLE
Rewardへの招待に関するフラッシュメッセージのバグの修正

### DIFF
--- a/app/models/reward.rb
+++ b/app/models/reward.rb
@@ -50,6 +50,10 @@ class Reward < ApplicationRecord
     all_valid
   end
 
+  def valid_invitation_token?(token)
+    invitation_token == token
+  end
+
   private
 
   def validate_in_progress

--- a/app/views/goals/_goal.html.erb
+++ b/app/views/goals/_goal.html.erb
@@ -1,6 +1,4 @@
 <%= turbo_frame_tag goal do %>
-  <%= render "layouts/flash" %>
-
   <div class="d-flex flex-column gap-2 h-100">
     <div class="fs-4">
       <% if goal.user.avatar.attached? %>

--- a/app/views/goals/update.turbo_stream.erb
+++ b/app/views/goals/update.turbo_stream.erb
@@ -1,1 +1,2 @@
 <%= turbo_stream.update dom_id(@goal), @goal %>
+<%= turbo_stream.update 'flash_messages', partial: "layouts/flash" %>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,21 +1,23 @@
-<% flash.each do |flash_type, message| %>
-  <% if flash_type == "notice" %>
-    <div class="toast-container top-0 end-0 p-3" data-controller="toast">
-      <div class="toast" data-bs-delay="3000" role="alert" aria-live="assertive" aria-atomic="true">
-        <div class="toast-header">
-          <%= image_tag('favicon.png', class: 'me-2', size: '20x20', alt: 'GifTreatのロゴ') %>
-          <strong class="me-auto">GifTreat</strong>
-          <button class="btn-close" data-bs-dismiss="toast"></button>
-        </div>
-        <div class="toast-body text-center">
-          <p class="fs-4", style="color: green"><%= message %>
+<div id="flash_messages">
+  <% flash.each do |flash_type, message| %>
+    <% if flash_type == "notice" %>
+      <div class="toast-container top-0 end-0 p-3" data-controller="toast">
+        <div class="toast" data-bs-delay="3000" role="alert" aria-live="assertive" aria-atomic="true">
+          <div class="toast-header">
+            <%= image_tag('favicon.png', class: 'me-2', size: '20x20', alt: 'GifTreatのロゴ') %>
+            <strong class="me-auto">GifTreat</strong>
+            <button class="btn-close" data-bs-dismiss="toast"></button>
+          </div>
+          <div class="toast-body text-center">
+            <p class="fs-4", style="color: green"><%= message %>
+          </div>
         </div>
       </div>
-    </div>
-  <% elsif flash_type == "alert" %>
-    <div class="alert alert-danger alert-dismissible fade show text-center" role="alert">
-      <strong><%= message %></strong>
-      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-    </div>
+    <% elsif flash_type == "alert" %>
+      <div class="alert alert-danger alert-dismissible fade show text-center" role="alert">
+        <strong><%= message %></strong>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+      </div>
+    <% end %>
   <% end %>
-<% end %>
+</div>

--- a/app/views/rewards/_reward.html.erb
+++ b/app/views/rewards/_reward.html.erb
@@ -1,6 +1,4 @@
 <%= turbo_frame_tag reward, class: 'd-flex text-center fs-2 m-2 gap-2' do %>
-  <%= render "layouts/flash" %>
-
   <div class="flex-grow-1 bg-body-secondary rounded p-1">
     <%= reward.completion_date %>
   </div>

--- a/app/views/rewards/update.turbo_stream.erb
+++ b/app/views/rewards/update.turbo_stream.erb
@@ -1,1 +1,2 @@
 <%= turbo_stream.update 'reward', @reward %>
+<%= turbo_stream.update 'flash_messages', partial: "layouts/flash" %>


### PR DESCRIPTION
## 概要：1つ目のバグ
+ 変更前：同じフラッシュメッセージが多数表示されてしまう
![image](https://github.com/user-attachments/assets/150023b2-aa2e-4e79-8455-21f0f71c387a)
+ 変更後
![image](https://github.com/user-attachments/assets/de77063b-cc29-4701-a03e-4e6b0956f3cd)

### 修正内容
+ `app/views/layouts/_flash.html.erb`に`id="flash_messages"`の追加した。
+ `update.turbo_stream.erb`の更新時に指定のID `"flash_messages"`のフラッシュメッセージをレンダリング 
`<%= turbo_stream.update 'flash_messages', partial: "layouts/flash" %>`するようにした。

## 概要：２つ目のバグ
+ 変更前：有効でない `invitation_token`であった場合に`無効な招待URLです。`というフラッシュメッセージが表示されない。
![image](https://github.com/user-attachments/assets/858edfb2-5aa0-4759-b528-94c29356e7f1)

+ 変更後
![image](https://github.com/user-attachments/assets/c035af0d-4be6-4ca4-8e97-e2196f365355)

### 修正内容
+ Rewardモデルで`params`で渡された`invitation_token`とrewardに関連する`invitation_token`が一致するかどうかを判定し、異なる場合は`goals_path`へリダイレクトさせて招待URLが無効であることをフラッシュメッセージで表示させる