### PR TITLE
招待機能に関する画面の修正

### DIFF
--- a/app/views/rewards/_reward.html.erb
+++ b/app/views/rewards/_reward.html.erb
@@ -26,6 +26,7 @@
         data: { controller: "clipboard",
                 action: "click->clipboard#copy",
                 clipboard_content_value: reward_url(@reward.id, invitation_token: @reward.invitation_token) },
+        title: "この招待URLでアクセスしたユーザのみが、このご褒美を共有できます。",
         class: 'btn btn-outline-secondary btn-sm'
       %>
     <% end %>


### PR DESCRIPTION
## issue
https://github.com/SuzukiShuntarou/GifTreat/issues/135

## 概要
+ 招待URLをコピーするボタンにマウスカーソルを合わせたときに招待URLで他のユーザが招待できることを表示。