### PR TITLE
目標の進捗率をスライダーで変更する機能に関するシステムテストの追加

### DIFF
--- a/test/system/goal_test.rb
+++ b/test/system/goal_test.rb
@@ -120,7 +120,36 @@ class GoalsTest < ApplicationSystemTestCase
     assert_text '目標の更新に成功！'
 
     within("div##{dom_id(@alice_goal_in_progress)}") do
+      assert_no_selector 'input[type="submit"][value="更新"]'
+      assert_no_selector 'a', text: '取消'
       assert_equal '100', find('input[name="goal[progress]"]').value
+    end
+  end
+
+  test 'should be able to cancel progress update with slider' do
+    visit reward_path(@alice_reward_in_progress)
+    progress_before_slider_operation = @alice_goal_in_progress.progress
+
+    within("div##{dom_id(@alice_goal_in_progress)}") do
+      assert_no_selector 'input[type="submit"][value="更新"]'
+      assert_no_selector 'a', text: '取消'
+
+      slider = find('input[type="range"]')
+      slider.send_keys(:home)
+      assert_equal '0', find('input[name="goal[progress]"]').value
+
+      assert_selector 'input[type="submit"][value="更新"]'
+      assert_selector 'a', text: '取消'
+
+      click_link_or_button '取消'
+    end
+
+    assert_current_path reward_path(@alice_reward_in_progress)
+
+    within("div##{dom_id(@alice_goal_in_progress)}") do
+      assert_no_selector 'input[type="submit"][value="更新"]'
+      assert_no_selector 'a', text: '取消'
+      assert_equal progress_before_slider_operation.to_s, find('input[name="goal[progress]"]').value
     end
   end
 end

--- a/test/system/goal_test.rb
+++ b/test/system/goal_test.rb
@@ -77,4 +77,26 @@ class GoalsTest < ApplicationSystemTestCase
     click_link_or_button '終了'
     assert_text '終了したご褒美と目標がありません。'
   end
+
+  test 'should be editable goal in progress' do
+    visit reward_path(@alice_reward_in_progress)
+
+    within("div##{dom_id(@alice_goal_in_progress)}") do
+      assert_selector 'a', text: '編集'
+      click_link_or_button '編集'
+    end
+
+    within('.modal-body') do
+      fill_in '目標', with: 'ランニングする'
+      fill_in '進捗率', with: '99'
+      click_link_or_button '更新'
+    end
+
+    assert_text '目標の更新に成功！'
+
+    within("div##{dom_id(@alice_goal_in_progress)}") do
+      assert_text 'ランニングする'
+      assert_equal '99', find('input[name="goal[progress]"]').value
+    end
+  end
 end

--- a/test/system/goal_test.rb
+++ b/test/system/goal_test.rb
@@ -99,4 +99,28 @@ class GoalsTest < ApplicationSystemTestCase
       assert_equal '99', find('input[name="goal[progress]"]').value
     end
   end
+
+  test 'should be able to update progress with slider' do
+    visit reward_path(@alice_reward_in_progress)
+
+    within("div##{dom_id(@alice_goal_in_progress)}") do
+      assert_no_selector 'input[type="submit"][value="更新"]'
+      assert_no_selector 'a', text: '取消'
+
+      slider = find('input[type="range"]')
+      slider.send_keys(:end)
+      assert_equal '100', find('input[name="goal[progress]"]').value
+
+      assert_selector 'input[type="submit"][value="更新"]'
+      assert_selector 'a', text: '取消'
+
+      click_link_or_button '更新'
+    end
+
+    assert_text '目標の更新に成功！'
+
+    within("div##{dom_id(@alice_goal_in_progress)}") do
+      assert_equal '100', find('input[name="goal[progress]"]').value
+    end
+  end
 end

--- a/test/system/reward_test.rb
+++ b/test/system/reward_test.rb
@@ -59,6 +59,7 @@ class RewardsTest < ApplicationSystemTestCase
       assert_text goal_completed.progress
 
       assert_no_selector 'a', text: '編集'
+      assert_no_selector 'input[type="range"]'
     end
   end
 

--- a/test/system/reward_test.rb
+++ b/test/system/reward_test.rb
@@ -118,7 +118,6 @@ class RewardsTest < ApplicationSystemTestCase
     end
   end
 
-
   test 'should delete reward and goal in progress' do
     visit reward_path(@reward_in_progress)
 

--- a/test/system/reward_test.rb
+++ b/test/system/reward_test.rb
@@ -118,27 +118,6 @@ class RewardsTest < ApplicationSystemTestCase
     end
   end
 
-  test 'should be editable goal in progress' do
-    visit reward_path(@reward_in_progress)
-
-    within("div##{dom_id(@goal_in_progress)}") do
-      assert_selector 'a', text: '編集'
-      click_link_or_button '編集'
-    end
-
-    within('.modal-body') do
-      fill_in '目標', with: 'ランニングする'
-      fill_in '進捗率', with: '99'
-      click_link_or_button '更新'
-    end
-
-    assert_text '目標の更新に成功！'
-
-    within("div##{dom_id(@goal_in_progress)}") do
-      assert_text 'ランニングする'
-      assert_equal '99', find('input[name="goal[progress]"]').value
-    end
-  end
 
   test 'should delete reward and goal in progress' do
     visit reward_path(@reward_in_progress)


### PR DESCRIPTION
## issue
+ https://github.com/SuzukiShuntarou/GifTreat/issues/62
+ https://github.com/SuzukiShuntarou/GifTreat/issues/140

## 概要
+ ご褒美の詳細画面に追加したスライダー機能について、スライダーによる目標の進捗率の `更新 / 取消`機能に関するシステムテストを追加。