### PR TITLE
ログインページのロゴの下に表示される文字色をメインカラーと同じ色にした

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -80,6 +80,10 @@ header {
   width: 100%;
 }
 
+.main-color {
+  color: $main-color;
+}
+
 a {
   color: $link-color;
   &:hover {

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:title, 'ログイン') %>
 <div class="d-flex flex-column justify-content-center align-items-center gap-3 m-3">
   <h1 class="text-center"><%= image_tag('logo-top-page', class: 'w-50 h-25', alt: 'GifTreatのロゴ') %></h1>
-  <h2>努力できた自分を褒めよう！</h2>
+  <h2 class="main-color">努力できた自分を褒めよう！</h2>
 
   <div class="fs-5" style="min-width: 25rem;">
     <%= bootstrap_form_with(model: @user, label_errors: true, url: session_path(resource_name), html: { method: :post }) do |f| %>


### PR DESCRIPTION
## issue
https://github.com/SuzukiShuntarou/GifTreat/issues/151

## 概要
+ トップページのロゴの下の説明文の色をメインカラーと同じ色に変更
![image](https://github.com/user-attachments/assets/6a78dd90-9094-4f4f-83c1-b8e3e09e5037)
