### PR TITLE
パスワード再設定用メールの内容とフラッシュメッセージの変更

### DIFF
--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,4 @@
-<p><%= t('.greeting', recipient: @resource.email) %></p>
-
-<p><%= t('.instruction') %></p>
-
+<p>いつもGifTreatをご利用いただきありがとうございます。</p>
+<p>以下のリンクからアクセスし、パスワードの再設定を行うことが可能です。</p>
 <p><%= link_to t('.action'), edit_password_url(@resource, reset_password_token: @token) %></p>
-
-<p><%= t('.instruction_2') %></p>
-<p><%= t('.instruction_3') %></p>
+<p>もしお心当たりがない場合は、本メールを破棄していただければと思います。</p>

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -60,12 +60,12 @@ ja:
         message: パスワードが再設定されました。
         subject: パスワードの変更について
       reset_password_instructions:
-        action: パスワード変更
+        action: パスワード再設定
         greeting: "%{recipient}様"
         instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
         instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
         instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
-        subject: パスワードの再設定について
+        subject: 【GifTreat】パスワードの再設定について
       unlock_instructions:
         action: アカウントのロック解除
         greeting: "%{recipient}様"

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -85,9 +85,9 @@ ja:
         forgot_your_password: パスワード再設定
         send_me_reset_password_instructions: 送信
       no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
-      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_instructions: パスワードの再設定について、メールでご連絡いたします。
       send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
-      updated: パスワードが正しく変更されました。
+      updated: パスワードが変更されました。
       updated_not_active: パスワードが正しく変更されました。
     registrations:
       destroyed: アカウントを削除しました。またのご利用をお待ちしております。

--- a/test/system/user_test.rb
+++ b/test/system/user_test.rb
@@ -105,7 +105,7 @@ class UsersTest < ApplicationSystemTestCase
     fill_in 'メールアドレス', with: 'alice@example.com'
     click_link_or_button '送信'
 
-    assert_text 'パスワードの再設定について数分以内にメールでご連絡いたします。'
+    assert_text 'パスワードの再設定について、メールでご連絡いたします。'
     assert_current_path new_user_session_path
 
     assert_equal 1, ActionMailer::Base.deliveries.size
@@ -121,7 +121,7 @@ class UsersTest < ApplicationSystemTestCase
     fill_in 'パスワード（確認用）', with: 'newpassword'
     click_link_or_button 'パスワード再設定'
 
-    assert_text 'パスワードが正しく変更されました。'
+    assert_text 'パスワードが変更されました。'
     find('.navbar-toggler').click
     click_link_or_button 'ログアウト'
     assert_text 'ログアウトしました。'

--- a/test/system/user_test.rb
+++ b/test/system/user_test.rb
@@ -111,7 +111,7 @@ class UsersTest < ApplicationSystemTestCase
     assert_equal 1, ActionMailer::Base.deliveries.size
     mail = ActionMailer::Base.deliveries.last
     assert_equal @current_user.email, mail.to[0]
-    assert_equal 'パスワードの再設定について', mail.subject
+    assert_equal '【GifTreat】パスワードの再設定について', mail.subject
 
     user = User.find_by(email: @current_user.email)
     token = user.send(:set_reset_password_token)


### PR DESCRIPTION
## issue
https://github.com/SuzukiShuntarou/GifTreat/issues/141

## 概要
+ パスワード再設定用のメールの本文の変更
+ メール配信時のフラッシュメッセージの調整