### PR TITLE
ナビゲーションウインドウの表示内容の修正

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -17,7 +17,7 @@
           <button type="button" class="btn-close" data-bs-dismiss="offcanvas"></button>
         </div>
         <div class="offcanvas-body mx-3">
-          <ul class="navbar-nav gap-3">
+          <ul class="navbar-nav gap-4 fs-5 mt-3">
             <li class="nav-item">
               <%= link_to 'トップページ', root_path %>
             </li>


### PR DESCRIPTION
## issue
https://github.com/SuzukiShuntarou/GifTreat/issues/157

## 概要
+ スマホではナビゲーションウインドウの文字が小さいため大きくした。