### PR TITLE
進捗率の取消ボタンの表示が中央揃えにならないバグの対応

### DIFF
--- a/app/views/goals/_goal.html.erb
+++ b/app/views/goals/_goal.html.erb
@@ -30,7 +30,7 @@
             <div class="col">
               <%= form.label :progress %>
             </div>
-            <div class="col d-flex gap-2">
+            <div class="col d-flex align-items-center gap-2 my-2">
               <%= form.number_field :progress, class: "text-center border border-primary-secondary rounded", style: "max-width: 10rem; outline: none;", readonly: true, id: "hidden_input_progress" %>%
               <div class="gap-3 mx-2" style="max-width: 15rem; display: none" id="update_buttons">
                 <%= form.submit "更新" , class: "btn btn-outline-primary" %>


### PR DESCRIPTION
## issue
https://github.com/SuzukiShuntarou/GifTreat/issues/156