### PR TITLE
Rewardコントローラのリファクタリング

### DIFF
--- a/app/controllers/rewards_controller.rb
+++ b/app/controllers/rewards_controller.rb
@@ -4,10 +4,9 @@ class RewardsController < ApplicationController
   before_action :set_reward, only: %i[edit update destroy invite]
 
   def show
-    reward_id = params[:id]
     invitation_token = params[:invitation_token]
     if invitation_token
-      @reward = Reward.find(reward_id)
+      @reward = Reward.find(params[:id])
       return redirect_to goals_path, alert: '無効な招待URLです。' unless @reward.valid_invitation_token?(invitation_token)
 
       invite_to_reward(@reward, current_user)

--- a/app/controllers/rewards_controller.rb
+++ b/app/controllers/rewards_controller.rb
@@ -12,9 +12,7 @@ class RewardsController < ApplicationController
 
       invite_to_reward(@reward, current_user)
     else
-      # 有効なinvitation_tokenがparamsにない場合、他人のRewardにアクセスできない
-      groups = RewardParticipant.includes(:reward).where(user: current_user)
-      @reward = groups.find_by!(reward_id:).reward
+      set_reward
     end
     @goals = @reward.goals.includes(user: :avatar_attachment).order(:id)
   end


### PR DESCRIPTION
## 概要
+ `reward`の`show`アクション（`params`に`invitaiton_token`がない場合）について、定義済の`set_reward`で`@reward`を取得するように変更