### PR TITLE
招待時のデータの保存失敗時にデータが保存されずにRewardの詳細画面にアクセスしてしまうバグの対応

### DIFF
--- a/app/models/reward.rb
+++ b/app/models/reward.rb
@@ -35,7 +35,6 @@ class Reward < ApplicationRecord
   end
 
   def self.bulk_create_by_invited(reward, current_user)
-    all_valid = true
     Reward.transaction do
       reward_participant = reward.reward_participants.build(user: current_user)
       initial_goal = reward.goals.build(
@@ -44,10 +43,8 @@ class Reward < ApplicationRecord
         progress: MIN_PROGRESS
       )
 
-      all_valid &= reward_participant.save && initial_goal.save
-      raise ActiveRecord::Rollback unless all_valid
+      reward_participant.save! && initial_goal.save!
     end
-    all_valid
   end
 
   def valid_invitation_token?(token)

--- a/test/models/goal_test.rb
+++ b/test/models/goal_test.rb
@@ -45,7 +45,9 @@ class GoalTest < ActiveSupport::TestCase
     another_user = users(:eve)
     assert_not RewardParticipant.find_by(user: another_user, reward: reward_related_max_count_goals).present?
 
-    Reward.bulk_create_by_invited(reward_related_max_count_goals, another_user)
+    assert_raises(ActiveRecord::RecordInvalid) do
+      Reward.bulk_create_by_invited(reward_related_max_count_goals, another_user)
+    end
     assert_not RewardParticipant.find_by(user: another_user, reward: reward_related_max_count_goals).present?
     assert_predicate reward_related_max_count_goals, :invalid?
   end


### PR DESCRIPTION
## 概要
+ 招待時の保存を `save`から`save!`に変更し、失敗時はエラーが発生して500ページへアクセスするようにした。