### PR TITLE
デプロイ時に拡張子の記載がないと画像を読み込めないバグへの対応

### DIFF
--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -2,7 +2,7 @@
 <div class="d-flex flex-column justify-content-center align-items-center gap-3 m-3">
   <h1 class="text-center">
     <%= link_to user_session_path do %>
-      <%= image_tag('logo-top-page', class: 'w-50 h-25', alt: 'GifTreatのロゴ') %>
+      <%= image_tag('logo-top-page.png', class: 'w-50 h-25', alt: 'GifTreatのロゴ') %>
     <% end %>
   </h1>
   <h2><%= t('.change_your_password') %></h2>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -2,7 +2,7 @@
 <div class="d-flex flex-column justify-content-center align-items-center gap-3 m-3">
   <h1 class="text-center">
     <%= link_to user_session_path do %>
-      <%= image_tag('logo-top-page', class: 'w-50 h-25', alt: 'GifTreatのロゴ') %>
+      <%= image_tag('logo-top-page.png', class: 'w-50 h-25', alt: 'GifTreatのロゴ') %>
     <% end %>
   </h1>
   <h2><%= t('.forgot_your_password') %></h2>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -2,7 +2,7 @@
 <div class="d-flex flex-column justify-content-center align-items-center gap-3 m-3">
   <h1 class="text-center">
     <%= link_to user_session_path do %>
-      <%= image_tag('logo-top-page', class: 'w-50 h-25', alt: 'GifTreatのロゴ') %>
+      <%= image_tag('logo-top-page.png', class: 'w-50 h-25', alt: 'GifTreatのロゴ') %>
     <% end %>
   </h1>
   <h2><%= t('.sign_up') %></h2>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title, 'ログイン') %>
 <section class="d-flex flex-column justify-content-center align-items-center gap-3 m-3">
-  <h1 class="text-center"><%= image_tag('logo-top-page', class: 'w-50 h-25', alt: 'GifTreatのロゴ') %></h1>
+  <h1 class="text-center"><%= image_tag('logo-top-page.png', class: 'w-50 h-25', alt: 'GifTreatのロゴ') %></h1>
   <h2 class="main-color">努力できた自分を褒めよう！</h2>
   <div class="fs-5" style="min-width: 25rem;">
     <%= bootstrap_form_with(model: @user, label_errors: true, url: session_path(resource_name), html: { method: :post }) do |f| %>
@@ -38,18 +38,18 @@
     <p class="fw-bold fs-4">STEP1</p>
     <p>ご褒美と目標を登録しよう！</p>
     <p>ご褒美は大きく！目標は小さな事から！</p>
-    <%= image_tag('example-step1-login-page', alt: 'ご褒美の登録例の実施中バージョン', style: 'max-height: 30rem;') %>
+    <%= image_tag('example-step1-login-page.png', alt: 'ご褒美の登録例の実施中バージョン', style: 'max-height: 30rem;') %>
   </div>
   <div class="d-flex flex-column align-items-center border border-primary-secondary rounded shadow-sm p-2 my-3" style="min-width: 25rem">
     <p class="fw-bold fs-4">STEP2</p>
     <p>忘れずに自分にご褒美をあげよう！</p>
     <p>努力できた自分を褒めてあげよう！</p>
-    <%= image_tag('example-step2-login-page', alt: 'ご褒美の登録例の完了後バージョン', style: 'max-height: 30rem;') %>
+    <%= image_tag('example-step2-login-page.png', alt: 'ご褒美の登録例の完了後バージョン', style: 'max-height: 30rem;') %>
   </div>
   <div class="d-flex flex-column align-items-center border border-primary-secondary rounded shadow-sm p-2 my-3" style="min-width: 25rem">
     <p class="fw-bold fs-4">STEP3</p>
     <p>友人や家族を招待することもできるよ！</p>
     <p>ご褒美を目指して一緒に頑張ろう！</p>
-    <%= image_tag('example-step3-login-page', alt: 'ご褒美の登録例の複数人バージョン', style: 'max-height: 30rem;') %>
+    <%= image_tag('example-step3-login-page.png', alt: 'ご褒美の登録例の複数人バージョン', style: 'max-height: 30rem;') %>
   </div>
 </section>

--- a/app/views/goals/_goal.html.erb
+++ b/app/views/goals/_goal.html.erb
@@ -19,7 +19,7 @@
     <div class="flex-grow-1 border border-primary-secondary bg-white rounded fs-4 p-3 position-relative">
       <div class="goal-description"><%= goal.description %></div>
       <% unless goal.reward.in_progress? %>
-        <% image = goal.achieved? ? "grade-very-good" : "grade-good" %>
+        <% image = goal.achieved? ? "grade-very-good.png" : "grade-good.png" %>
         <%= image_tag(image, class: "position-absolute bottom-0 end-0 h-25") %>
       <% end %>
     </div>

--- a/app/views/welcome/privacy_policy.html.erb
+++ b/app/views/welcome/privacy_policy.html.erb
@@ -4,7 +4,7 @@
   <% unless user_signed_in? %>
     <h1 class="text-center">
       <%= link_to user_session_path do %>
-        <%= image_tag('logo-top-page', class: 'w-50 h-25', alt: 'GifTreatのロゴ') %>
+        <%= image_tag('logo-top-page.png', class: 'w-50 h-25', alt: 'GifTreatのロゴ') %>
       <% end %>
     </h1>
   <% end %>

--- a/app/views/welcome/terms_service.html.erb
+++ b/app/views/welcome/terms_service.html.erb
@@ -4,7 +4,7 @@
   <% unless user_signed_in? %>
     <h1 class="text-center">
       <%= link_to user_session_path do %>
-        <%= image_tag('logo-top-page', class: 'w-50 h-25', alt: 'GifTreatのロゴ') %>
+        <%= image_tag('logo-top-page.png', class: 'w-50 h-25', alt: 'GifTreatのロゴ') %>
       <% end %>
     </h1>
   <% end %>


### PR DESCRIPTION
## 概要
+ `image_tag`の指定した画像に拡張子がついていないとエラーとなるため全てに追加した。