### PR TITLE
デフォルトのタイトルが表示されるバグへの対応

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,13 +8,12 @@ module ApplicationHelper
 
   def default_meta_tags
     {
-      site: 'GifTreat',
       reverse: true,
       charset: 'utf-8',
       description: 'GifTreatは自分にご褒美をあげたい人向けのご褒美設定サービスです。',
       keywords: 'GifTreat,ご褒美,ご褒美の共有',
       og: {
-        site_name: :site,
+        site_name: 'GifTreat',
         title: :title,
         description: :description,
         type: 'website',


### PR DESCRIPTION
## issue
+ https://github.com/SuzukiShuntarou/GifTreat/issues/192

## 概要
+ `default_meta_tags`での`site`の設定が優先されていた。`og: site_name: 'GifTreat'`を設定したので`site`を削除して動的にタイトルが表示されるようにした