### PR TITLE
画像のアップロードサイズにバリデーションを追加した

### DIFF
--- a/app/helpers/avatars_helper.rb
+++ b/app/helpers/avatars_helper.rb
@@ -3,7 +3,8 @@
 module AvatarsHelper
   def avatar_path(avatar)
     if Rails.env.production?
-      ENV.fetch('PUBLIC_URL', nil) + avatar.variant(:profile_icon).key
+      key = avatar.variant(:profile_icon).key || avatar.key
+      ENV.fetch('PUBLIC_URL', nil) + key
     else
       avatar.variant(:profile_icon)
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   ACCEPTED_CONTENT_TYPES = ['image/png', 'image/jpeg', 'image/gif'].freeze
+  MAX_AVATAR_SIZE = 500
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
@@ -16,5 +17,6 @@ class User < ApplicationRecord
     attachable.variant :profile_icon, resize_to_limit: [75, 75]
   end
   validates :name, presence: true, length: { maximum: 10 }
-  validates :avatar, content_type: { in: ACCEPTED_CONTENT_TYPES, message: :content_type }
+  validates :avatar, content_type: { in: ACCEPTED_CONTENT_TYPES, message: :content_type },
+                     size: { less_than: MAX_AVATAR_SIZE.kilobytes, message: "ファイルサイズは#{MAX_AVATAR_SIZE}KB以下にしてください" }
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -6,7 +6,7 @@
   <div class="fs-5" style="min-width: 25rem;">
     <%= bootstrap_form_with(model: @user, label_errors: true, url: registration_path(resource_name), html: { method: :put }) do |f| %>
       <div class="field">
-        <% if resource.avatar.attached? && resource.avatar.variable? %>
+        <% if !resource.errors[:avatar].any? && resource.avatar.attached? %>
           <%= f.label :avatar do %>
             現在のアイコン
             <%= image_tag(avatar_path(resource.avatar),


### PR DESCRIPTION
## 概要
+ 画像のサイズについて最大サイズのバリデーションを追加した。
+ `avatar`についてバリデーションエラーがある場合
![image](https://github.com/user-attachments/assets/1dc4bfc8-15d0-4aac-b8e7-ec980bca1166)

+ バリデーションエラーがない場合は登録されたアイコン画像が表示
![image](https://github.com/user-attachments/assets/a2f2fa08-92a1-4ef5-9bb6-20469f60eb6e)

+ `avatar`以外のエラーの時は通常通り表示する
![image](https://github.com/user-attachments/assets/8a6bc9c8-9f9b-48df-b3fb-5665a3ea4415)

## issue
+ https://github.com/SuzukiShuntarou/GifTreat/issues/195