### PR TITLE
avatarに関する設定の変更

### DIFF
--- a/app/helpers/avatars_helper.rb
+++ b/app/helpers/avatars_helper.rb
@@ -3,8 +3,7 @@
 module AvatarsHelper
   def avatar_path(avatar)
     if Rails.env.production?
-      key = avatar.variant(:profile_icon).key || avatar.key
-      ENV.fetch('PUBLIC_URL', nil) + key
+      ENV.fetch('PUBLIC_URL', nil) + avatar.key
     else
       avatar
     end

--- a/app/helpers/avatars_helper.rb
+++ b/app/helpers/avatars_helper.rb
@@ -6,7 +6,7 @@ module AvatarsHelper
       key = avatar.variant(:profile_icon).key || avatar.key
       ENV.fetch('PUBLIC_URL', nil) + key
     else
-      avatar.variant(:profile_icon)
+      avatar
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,9 +13,7 @@ class User < ApplicationRecord
   has_many :goals, dependent: :destroy
   has_many :likings, dependent: :destroy
   has_many :cheerings, dependent: :destroy
-  has_one_attached :avatar do |attachable|
-    attachable.variant :profile_icon, resize_to_limit: [75, 75]
-  end
+  has_one_attached :avatar
   validates :name, presence: true, length: { maximum: 10 }
   validates :avatar, content_type: { in: ACCEPTED_CONTENT_TYPES, message: :content_type },
                      size: { less_than: MAX_AVATAR_SIZE.kilobytes, message: "ファイルサイズは#{MAX_AVATAR_SIZE}KB以下にしてください" }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   ACCEPTED_CONTENT_TYPES = ['image/png', 'image/jpeg', 'image/gif'].freeze
-  MAX_AVATAR_SIZE = 500
+  MAX_AVATAR_SIZE = 1
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
@@ -16,5 +16,5 @@ class User < ApplicationRecord
   has_one_attached :avatar
   validates :name, presence: true, length: { maximum: 10 }
   validates :avatar, content_type: { in: ACCEPTED_CONTENT_TYPES, message: :content_type },
-                     size: { less_than: MAX_AVATAR_SIZE.kilobytes, message: "ファイルサイズは#{MAX_AVATAR_SIZE}KB以下にしてください" }
+                     size: { less_than: MAX_AVATAR_SIZE.megabytes, message: "ファイルサイズは#{MAX_AVATAR_SIZE}MB以下にしてください" }
 end


### PR DESCRIPTION
## 概要
+ リサイズの設定を削除
+ アップロードするアイコン画像のバリデーションの最大サイズを 500 KB(0.5MB) → 1MBへ変更。（ストレージの最大容量を勘違いしていたため小さくし過ぎていた。）

## メモ
+ iPhoneなどの写真は3MBが主流らしいが、今回は1MBを最大とした。