### PR TITLE
Rewardの招待用URLをコントローラからビューへ渡す方法に変更した

### DIFF
--- a/app/controllers/rewards_controller.rb
+++ b/app/controllers/rewards_controller.rb
@@ -45,7 +45,9 @@ class RewardsController < ApplicationController
     redirect_to goals_path, notice: 'ご褒美の削除に成功！'
   end
 
-  def invite; end
+  def invite
+    @invite_url = reward_url(params[:id], invitation_token: @reward.invitation_token)
+  end
 
   private
 

--- a/app/views/rewards/_reward.html.erb
+++ b/app/views/rewards/_reward.html.erb
@@ -26,8 +26,8 @@
     <% if reward.in_progress? %>
       <%= link_to "編集", edit_reward_path(reward), class: 'btn btn-outline-secondary', data: { turbo_frame: "modal"} %>
     <% end %>
-    <% if invited?(@reward) %>
-      <%= link_to '招待', invite_reward_path(@reward), class: 'btn btn-outline-secondary', data: { turbo_frame: "modal"} %>
+    <% if invited?(reward) %>
+      <%= link_to '招待', invite_reward_path(reward), class: 'btn btn-outline-secondary', data: { turbo_frame: "modal"} %>
     <% end %>
   </div>
 </div>

--- a/app/views/rewards/invite.html.erb
+++ b/app/views/rewards/invite.html.erb
@@ -7,14 +7,14 @@
     </div>
     <div class="d-flex gap-3">
       <%= text_field_tag :invite_url,
-          reward_url(@reward.id, invitation_token: @reward.invitation_token),
+          @invite_url,
           readonly: true,
           class: 'flex-grow-1 border border-primary-secondary rounded bg-white text-center'
       %>
       <%= button_tag '招待用URLをコピー', 
         data: { controller: "clipboard",
                 action: "click->clipboard#copy",
-                clipboard_content_value: reward_url(@reward.id, invitation_token: @reward.invitation_token) },
+                clipboard_content_value: @invite_url },
         class: 'btn btn-primary btn-sm'
       %>
     </div>


### PR DESCRIPTION
## 概要
+ ビューで直接URLを生成していたので`invite`アクションで`params[:id]`と`invitation_token`を取得し、生成したURLをインスタンス変数で渡す方法に変更した。