### PR TITLE
招待に関するヘルパーメソッドの修正

### DIFF
--- a/app/helpers/rewards_helper.rb
+++ b/app/helpers/rewards_helper.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module RewardsHelper
-  MAX_REWARD_RELATED_GOALS = 4
+  MAX_REWARD_PARTICIPANTS = 4
 
-  def invited?(reward)
-    reward.in_progress? && reward.goals.count < MAX_REWARD_RELATED_GOALS
+  def max_reward_participants?(reward)
+    reward.reward_participants.count >= MAX_REWARD_PARTICIPANTS
   end
 end

--- a/app/views/rewards/_reward.html.erb
+++ b/app/views/rewards/_reward.html.erb
@@ -25,9 +25,9 @@
   <div class="d-flex align-items-center gap-2 ">
     <% if reward.in_progress? %>
       <%= link_to "編集", edit_reward_path(reward), class: 'btn btn-outline-secondary', data: { turbo_frame: "modal"} %>
-    <% end %>
-    <% if invited?(reward) %>
-      <%= link_to '招待', invite_reward_path(reward), class: 'btn btn-outline-secondary', data: { turbo_frame: "modal"} %>
+      <% unless max_reward_participants?(reward) %>
+        <%= link_to '招待', invite_reward_path(reward), class: 'btn btn-outline-secondary', data: { turbo_frame: "modal"} %>
+      <% end %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
## 概要
+ ヘルパーメソッドの命名が正しくなかったため修正。
+ ヘルパーメソッドで`in_progrees?`を確認するのではなく、編集ボタンと同じ条件分岐で確認させるように修正。