### PR TITLE
ルートパスの指定ミスによる不適切なアラートが表示されてしまうバグへの対応

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,11 +7,11 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   def after_sign_in_path_for(resource)
-    stored_location_for(resource) || root_path
+    stored_location_for(resource) || goals_path
   end
 
   def after_sign_up_path_for(resource)
-    stored_location_for(resource) || root_path
+    stored_location_for(resource) || goals_path
   end
 
   def after_sign_out_path_for(_resource)

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -19,7 +19,7 @@
         <div class="offcanvas-body mx-3">
           <ul class="navbar-nav gap-4 fs-5 mt-3">
             <li class="nav-item">
-              <%= link_to 'トップページ', root_path %>
+              <%= link_to 'トップページ', goals_path %>
             </li>
             <li class="nav-item">
               <%= link_to 'ご褒美を追加する', new_reward_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
-  root to: redirect('/goals')
+  devise_scope :user do
+    root to: 'devise/sessions#new'
+  end
 
   devise_for :users, controllers: {
     registrations: "users/registrations"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
+  authenticated :user do
+    root to: 'goals#index', as: :authenticated_root
+  end
+
   devise_scope :user do
     root to: 'devise/sessions#new'
   end

--- a/test/system/cheering_test.rb
+++ b/test/system/cheering_test.rb
@@ -6,7 +6,7 @@ class CheeringsTest < ApplicationSystemTestCase
   setup do
     current_user = users(:alice)
     sign_in current_user
-    visit root_path
+    visit goals_path
   end
 
   test 'should increase count when cheering button clicked' do

--- a/test/system/goal_test.rb
+++ b/test/system/goal_test.rb
@@ -12,7 +12,7 @@ class GoalsTest < ApplicationSystemTestCase
 
     current_user = users(:alice)
     sign_in current_user
-    visit root_path
+    visit goals_path
   end
 
   test 'should display goals list screen when nav-logo clicked' do
@@ -69,7 +69,7 @@ class GoalsTest < ApplicationSystemTestCase
 
     user_without_rewards_and_goals = users(:user_without_rewards_goals)
     sign_in user_without_rewards_and_goals
-    visit root_path
+    visit goals_path
 
     click_link_or_button '実施中'
     assert_text 'ご褒美と目標が登録されていません。'

--- a/test/system/liking_test.rb
+++ b/test/system/liking_test.rb
@@ -6,7 +6,7 @@ class LikingsTest < ApplicationSystemTestCase
   setup do
     current_user = users(:alice)
     sign_in current_user
-    visit root_path
+    visit goals_path
   end
 
   test 'should increase count when liking button clicked' do

--- a/test/system/navigation_test.rb
+++ b/test/system/navigation_test.rb
@@ -6,7 +6,7 @@ class NavigationBarTest < ApplicationSystemTestCase
   setup do
     current_user = users(:alice)
     sign_in current_user
-    visit root_path
+    visit goals_path
   end
 
   test 'should display link in offcanvas when clicked navigation bar button' do

--- a/test/system/reward_test.rb
+++ b/test/system/reward_test.rb
@@ -9,7 +9,7 @@ class RewardsTest < ApplicationSystemTestCase
 
     current_user = users(:alice)
     sign_in current_user
-    visit root_path
+    visit goals_path
   end
 
   test 'should show details of Reward and Goal, with edit and delete and invite buttons, in progress' do

--- a/test/system/user_test.rb
+++ b/test/system/user_test.rb
@@ -25,7 +25,7 @@ class UsersTest < ApplicationSystemTestCase
 
   test 'should logout' do
     sign_in @current_user
-    visit root_path
+    visit goals_path
     find('.navbar-toggler').click
     click_link_or_button 'ログアウト'
     assert_text 'ログアウトしました。'
@@ -33,7 +33,7 @@ class UsersTest < ApplicationSystemTestCase
 
   test 'should show own user edit page' do
     sign_in @current_user
-    visit root_path
+    visit goals_path
     find('.navbar-toggler').click
     click_link_or_button '登録情報'
 
@@ -44,7 +44,7 @@ class UsersTest < ApplicationSystemTestCase
 
   test 'should editable registration' do
     sign_in @current_user
-    visit root_path
+    visit goals_path
     find('.navbar-toggler').click
     click_link_or_button '登録情報'
 
@@ -63,7 +63,7 @@ class UsersTest < ApplicationSystemTestCase
 
   test 'should be able to delete own account from user edit page' do
     sign_in @current_user
-    visit root_path
+    visit goals_path
     find('.navbar-toggler').click
     click_link_or_button '登録情報'
 


### PR DESCRIPTION
## 概要
- ルートパスをログイン後画面にしていることでサイトにアクセスすると「ログインもしくはアカウント登録してください。」と表示されてしまうバグへの対応。
- ログイン後のルートパスを指定しない場合「ログイン済です」と表示されるためログインしている場合のルートパスを指定した。