### PR TITLE
flakyなテストの修正

### DIFF
--- a/test/system/navigation_test.rb
+++ b/test/system/navigation_test.rb
@@ -55,6 +55,7 @@ class NavigationBarTest < ApplicationSystemTestCase
   test 'should hide offcanvas when clicked close button' do
     find("[aria-label='ナビゲーションバーの表示ボタン']").click
     within('#offcanvasNavbar') { find("[aria-label='ナビゲーションバーの非表示ボタン']").click }
+    sleep 5
 
     assert_current_path goals_path
     assert_text '目標一覧'

--- a/test/system/reward_test.rb
+++ b/test/system/reward_test.rb
@@ -258,6 +258,8 @@ class RewardsTest < ApplicationSystemTestCase
     click_link_or_button '更新'
 
     visit reward_path(@reward_in_progress)
+    assert_text 'ご褒美'
+    assert_text '目標'
     assert_selector 'img[alt="ユーザのアイコン"]'
     assert_no_selector 'img[alt="デフォルトのユーザアイコン"]'
   end


### PR DESCRIPTION
## 概要
- アバターの画像表示については`assert_text`でcapybaraにテキストを検索させて待たせるようにした。
- ナビゲーションバーについては元の画面が表示されたままであったことから`assert_selector`などを使用しても[flakyなまま（ローカルでは通る）であった](https://github.com/SuzukiShuntarou/GifTreat/pull/219)ため、`sleep`を追加した。
  - 5回中1回落ちたことを確認した。
![image](https://github.com/user-attachments/assets/0bc5b046-5cb4-450c-82a4-30979c2684d4)
