### PR TITLE
ご褒美と目標の詳細画面についてデザインレビューを元に修正した

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -146,17 +146,6 @@ h3 {
   }
 }
 
-.btn-outline-danger {
-  color: $warning-color;
-  border-color: $warning-color;
-  &:hover {
-    color: $base-color !important;
-    background-color: $warning-color !important;
-    border-color: $warning-color !important;
-    opacity: 1;
-  }
-}
-
 .page-link {
   color: $link-color;
 }

--- a/app/views/goals/_goal.html.erb
+++ b/app/views/goals/_goal.html.erb
@@ -34,7 +34,7 @@
               <%= form.label :progress %>
               <%= form.number_field :progress, class: "text-center px-2 py-1 border border-primary-secondary rounded", style: "max-width: 5rem; outline: none;", readonly: true, id: "hidden_input_progress" %>%
               <div class="align-items-center ms-2 gap-3" style="display: none" id="update_buttons">
-                <%= form.submit "更新", class: "btn btn-outline-primary", style: "width: 6rem" %>
+                <%= form.submit "更新", class: "btn btn-outline-primary", style: "width: 5rem" %>
                 <%= link_to "キャンセル", reward_path(goal.reward), class: "link-offset-1", style: "font-size: 0.8rem" %>
               </div>
             </div>

--- a/app/views/goals/_goal.html.erb
+++ b/app/views/goals/_goal.html.erb
@@ -33,9 +33,9 @@
             <div class="col d-flex align-items-center gap-1 my-2", style="height: 2.5rem" >
               <%= form.label :progress %>
               <%= form.number_field :progress, class: "text-center px-2 py-1 border border-primary-secondary rounded", style: "max-width: 5rem; outline: none;", readonly: true, id: "hidden_input_progress" %>%
-              <div class="ms-3 gap-3" style="display: none" id="update_buttons">
+              <div class="align-items-center ms-3 gap-3" style="display: none" id="update_buttons">
                 <%= form.submit "更新", class: "btn btn-outline-primary", style: "width: 4rem" %>
-                <%= link_to "取消", reward_path(goal.reward), class: "btn btn-outline-danger", style: "width: 4rem" %>
+                <%= link_to "キャンセル", reward_path(goal.reward), class: "link-offset-1" %>
               </div>
             </div>
           <% end %>

--- a/app/views/goals/_goal.html.erb
+++ b/app/views/goals/_goal.html.erb
@@ -33,9 +33,9 @@
             <div class="col d-flex align-items-center gap-1 my-2", style="height: 2.5rem" >
               <%= form.label :progress %>
               <%= form.number_field :progress, class: "text-center px-2 py-1 border border-primary-secondary rounded", style: "max-width: 5rem; outline: none;", readonly: true, id: "hidden_input_progress" %>%
-              <div class="align-items-center ms-3 gap-3" style="display: none" id="update_buttons">
-                <%= form.submit "更新", class: "btn btn-outline-primary", style: "width: 4rem" %>
-                <%= link_to "キャンセル", reward_path(goal.reward), class: "link-offset-1" %>
+              <div class="align-items-center ms-2 gap-3" style="display: none" id="update_buttons">
+                <%= form.submit "更新", class: "btn btn-outline-primary", style: "width: 6rem" %>
+                <%= link_to "キャンセル", reward_path(goal.reward), class: "link-offset-1", style: "font-size: 0.8rem" %>
               </div>
             </div>
           <% end %>

--- a/app/views/goals/_goal.html.erb
+++ b/app/views/goals/_goal.html.erb
@@ -33,7 +33,7 @@
             <div class="col d-flex align-items-center gap-1 my-2", style="height: 2.5rem" >
               <%= form.label :progress %>
               <%= form.number_field :progress, class: "text-center px-2 py-1 border border-primary-secondary rounded", style: "max-width: 5rem; outline: none;", readonly: true, id: "hidden_input_progress" %>%
-              <div class="align-items-center ms-2 gap-3" style="display: none" id="update_buttons">
+              <div class="align-items-center ms-3 gap-3" style="display: none" id="update_buttons">
                 <%= form.submit "更新", class: "btn btn-outline-primary", style: "width: 5rem" %>
                 <%= link_to "キャンセル", reward_path(goal.reward), class: "link-offset-1", style: "font-size: 0.8rem" %>
               </div>

--- a/app/views/rewards/_reward.html.erb
+++ b/app/views/rewards/_reward.html.erb
@@ -26,7 +26,7 @@
   <% if reward.in_progress? %>
     <%= link_to "編集", edit_reward_path(reward), class: 'btn btn-outline-secondary fs-5', style: 'width: 8rem', data: { turbo_frame: "modal"} %>
     <% unless reward.max_reward_participants? %>
-      <%= link_to '招待', invite_reward_path(reward), class: 'btn btn-outline-secondary fs-5', style: 'width: 8rem', data: { turbo_frame: "modal"} %>
+      <%= link_to 'このご褒美に招待する', invite_reward_path(reward), class: 'btn btn-outline-secondary fs-5', style: 'width: 8rem', data: { turbo_frame: "modal"} %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/rewards/_reward.html.erb
+++ b/app/views/rewards/_reward.html.erb
@@ -6,7 +6,9 @@
     </div>
     <div class="d-flex flex-nowrap border-top w-100 pt-3 px-2">
       <span class="ps-3" style="font-size: 0.8rem;">開催日</span>
-      <span class="flex-grow-1 text-center fw-semibold pe-4" style="font-size: 1.25rem;"><%= reward.completion_date %></span>
+      <span class="flex-grow-1 text-center fw-semibold pe-4" style="font-size: 1.25rem;">
+        <%= l reward.completion_date, format: :long %>
+      </span>
     </div>
   </div>
 <% end %>

--- a/app/views/rewards/_reward.html.erb
+++ b/app/views/rewards/_reward.html.erb
@@ -1,32 +1,21 @@
-<%= turbo_frame_tag reward, class: 'd-flex text-center' do %>
-  <div class="d-flex align-items-center mb-2">
-    <div class="border border-primary-secondary bg-white rounded px-1 py-2">
-      <%= reward.completion_date %>
+<%= turbo_frame_tag reward do %>
+  <div class="d-flex flex-column align-items-center">
+    <div class="fw-medium px-2 pb-3" style="font-size: 1.1rem;">
+      <%= reward.location %>で
+      <%= reward.description %>する
     </div>
-    <span class="mx-2">に</span>
-  </div>
-  <div class="d-flex flex-grow-1 flex-nowrap align-items-center mb-2">
-    <div class="flex-grow-1 border border-primary-secondary bg-white rounded px-1 py-2">
-      <%= reward.location %>
+    <div class="d-flex flex-nowrap border-top w-100 pt-3 px-2">
+      <span class="ps-3" style="font-size: 0.8rem;">開催日</span>
+      <span class="flex-grow-1 text-center fw-semibold pe-4" style="font-size: 1.25rem;"><%= reward.completion_date %></span>
     </div>
-    <span class="ms-2">で</span>
   </div>
 <% end %>
 
-<%= turbo_frame_tag reward, class: 'text-center' do %>
-  <div class="d-flex flex-grow-1 flex-nowrap align-items-center">
-    <div class="flex-grow-1 border border-primary-secondary bg-white rounded px-1 py-2">
-      <%= reward.description %>
-    </div>
-    <span class="text-nowrap ms-2">する</span>
-  </div>
-<% end %>
-
-<div class="d-flex align-items-center justify-content-center mt-2 gap-3">
-  <% if reward.in_progress? %>
-    <%= link_to "編集", edit_reward_path(reward), class: 'btn btn-outline-secondary fs-5', style: 'width: 8rem', data: { turbo_frame: "modal"} %>
+<% if reward.in_progress? %>
+  <div class="d-flex border-top justify-content-center px-2 mt-3 pt-3 gap-3">
     <% unless reward.max_reward_participants? %>
-      <%= link_to 'このご褒美に招待する', invite_reward_path(reward), class: 'btn btn-outline-secondary fs-5', style: 'width: 8rem', data: { turbo_frame: "modal"} %>
+      <%= link_to 'ご褒美に招待する', invite_reward_path(reward), class: 'btn btn-outline-secondary w-75 fs-5', data: { turbo_frame: "modal"} %>
     <% end %>
-  <% end %>
-</div>
+    <%= link_to "編集", edit_reward_path(reward), class: 'btn btn-outline-secondary flex-grow-1 fs-5', style: "max-width: 6rem", data: { turbo_frame: "modal"} %>
+  </div>
+<% end %>

--- a/app/views/rewards/show.html.erb
+++ b/app/views/rewards/show.html.erb
@@ -34,12 +34,13 @@
         </div>
       <% end %>
     </div>
-  </section>
-  <% if @reward.in_progress? %>
-    <section>
-      <div class="my-3">
-        <%= link_to "削除", @reward, data: { turbo_method: :delete, turbo_confirm: "削除しますか？" } %>
+    <% if @reward.in_progress? %>
+      <div class="d-flex justify-content-end pe-2" style="font-size: 0.85rem;">
+        <%= link_to "削除", @reward, data: { turbo_method: :delete, turbo_confirm: "ご褒美と目標をすべて削除しますか？" } %>
       </div>
-    </section>
-  <% end %>
+    <% end %>
+  </section>
+  <section class="mt-1 mb-3">
+    <%= link_to "目標一覧に戻る", goals_path %>
+  </section>
 </div>

--- a/app/views/rewards/show.html.erb
+++ b/app/views/rewards/show.html.erb
@@ -5,7 +5,7 @@
 <div class="d-flex flex-column align-items-center my-2 px-2">
   <section style="min-width: 22rem; max-width: 45rem;">
     <h3 class="border border-secondary-subtle rounded-top text-center main-color py-2 mt-1 mb-0">ご褒美</h3>
-    <div class="d-flex flex-column border border-secondary-subtle border-top-0 rounded-bottom shadow-sm mb-3 px-2 py-3">
+    <div class="flex-column border border-secondary-subtle border-top-0 rounded-bottom shadow-sm mb-3 py-3">
       <div id='reward'>
         <%= render @reward %>
       </div>

--- a/app/views/rewards/show.html.erb
+++ b/app/views/rewards/show.html.erb
@@ -3,7 +3,7 @@
 <h2 class="main-color text-center w-100 title-bg-color py-3">ご褒美・目標詳細</h2>
 
 <div class="d-flex flex-column align-items-center my-2 px-2">
-  <section style="min-width: 22rem; max-width: 45rem;">
+  <section style="width: 22rem;">
     <h3 class="border border-secondary-subtle rounded-top text-center main-color py-2 mt-1 mb-0">ご褒美</h3>
     <div class="flex-column border border-secondary-subtle border-top-0 rounded-bottom shadow-sm mb-3 py-3">
       <div id='reward'>
@@ -14,7 +14,7 @@
   <section>
     <div class="d-flex gap-2 justify-content-center">
       <% @goals.each do |goal| %>
-        <div class="d-flex flex-column justify-content-center" style="min-width: 22rem; max-width: 30rem;">
+        <div class="d-flex flex-column justify-content-center" style="width: 22rem;">
           <h3 class="border border-secondary-subtle rounded-top text-center main-color py-2 mt-1 mb-0">
             <%= "#{goal.user.name}の目標" %>
           </h3>

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -15,7 +15,7 @@ ja:
       reward:
         description: ご褒美
         location: 場所
-        completion_date: 期日
+        completion_date: 開催日
       reward/goals:
         description: 目標
         progress: 進捗率

--- a/test/system/goal_test.rb
+++ b/test/system/goal_test.rb
@@ -107,14 +107,14 @@ class GoalsTest < ApplicationSystemTestCase
 
     within("div##{dom_id(@alice_goal_in_progress)}") do
       assert_no_selector 'input[type="submit"][value="更新"]'
-      assert_no_selector 'a', text: '取消'
+      assert_no_selector 'a', text: 'キャンセル'
 
       slider = find('input[type="range"]')
       slider.send_keys(:end)
       assert_equal '100', find('input[name="goal[progress]"]').value
 
       assert_selector 'input[type="submit"][value="更新"]'
-      assert_selector 'a', text: '取消'
+      assert_selector 'a', text: 'キャンセル'
 
       click_link_or_button '更新'
     end
@@ -123,7 +123,7 @@ class GoalsTest < ApplicationSystemTestCase
 
     within("div##{dom_id(@alice_goal_in_progress)}") do
       assert_no_selector 'input[type="submit"][value="更新"]'
-      assert_no_selector 'a', text: '取消'
+      assert_no_selector 'a', text: 'キャンセル'
       assert_equal '100', find('input[name="goal[progress]"]').value
     end
   end
@@ -134,23 +134,23 @@ class GoalsTest < ApplicationSystemTestCase
 
     within("div##{dom_id(@alice_goal_in_progress)}") do
       assert_no_selector 'input[type="submit"][value="更新"]'
-      assert_no_selector 'a', text: '取消'
+      assert_no_selector 'a', text: 'キャンセル'
 
       slider = find('input[type="range"]')
       slider.send_keys(:home)
       assert_equal '0', find('input[name="goal[progress]"]').value
 
       assert_selector 'input[type="submit"][value="更新"]'
-      assert_selector 'a', text: '取消'
+      assert_selector 'a', text: 'キャンセル'
 
-      click_link_or_button '取消'
+      click_link_or_button 'キャンセル'
     end
 
     assert_current_path reward_path(@alice_reward_in_progress)
 
     within("div##{dom_id(@alice_goal_in_progress)}") do
       assert_no_selector 'input[type="submit"][value="更新"]'
-      assert_no_selector 'a', text: '取消'
+      assert_no_selector 'a', text: 'キャンセル'
       assert_equal progress_before_slider_operation.to_s, find('input[name="goal[progress]"]').value
     end
   end

--- a/test/system/reward_test.rb
+++ b/test/system/reward_test.rb
@@ -16,7 +16,7 @@ class RewardsTest < ApplicationSystemTestCase
     visit reward_path(@reward_in_progress)
 
     within('#reward') do
-      assert_text @reward_in_progress.completion_date
+      assert_text I18n.l(@reward_in_progress.completion_date, format: :long)
       assert_text @reward_in_progress.location
       assert_text @reward_in_progress.description
 
@@ -44,7 +44,7 @@ class RewardsTest < ApplicationSystemTestCase
     visit reward_path(reward_completed)
 
     within('#reward') do
-      assert_text reward_completed.completion_date
+      assert_text I18n.l(reward_completed.completion_date, format: :long)
       assert_text reward_completed.location
       assert_text reward_completed.description
 
@@ -83,7 +83,7 @@ class RewardsTest < ApplicationSystemTestCase
     assert_current_path "/rewards/#{reward.id}"
 
     within('#reward') do
-      assert_text Date.current.tomorrow
+      assert_text I18n.l(Date.current.tomorrow, format: :long)
       assert_text '叙々苑'
       assert_text '焼肉'
     end
@@ -164,7 +164,7 @@ class RewardsTest < ApplicationSystemTestCase
 
     assert_text 'ご褒美に招待されました！'
     within('#reward') do
-      assert_text @reward_in_progress.completion_date
+      assert_text I18n.l(@reward_in_progress.completion_date, format: :long)
       assert_text @reward_in_progress.location
       assert_text @reward_in_progress.description
     end

--- a/test/system/reward_test.rb
+++ b/test/system/reward_test.rb
@@ -263,4 +263,11 @@ class RewardsTest < ApplicationSystemTestCase
     assert_selector 'img[alt="ユーザのアイコン"]'
     assert_no_selector 'img[alt="デフォルトのユーザアイコン"]'
   end
+
+  test 'should access list of goals' do
+    visit reward_path(@reward_in_progress)
+    assert_selector 'a', text: '目標一覧に戻る'
+    click_link_or_button '目標一覧に戻る'
+    assert_current_path goals_path
+  end
 end

--- a/test/system/reward_test.rb
+++ b/test/system/reward_test.rb
@@ -21,7 +21,7 @@ class RewardsTest < ApplicationSystemTestCase
       assert_text @reward_in_progress.description
 
       assert_selector 'a', text: '編集'
-      assert_selector 'a', text: 'このご褒美に招待する'
+      assert_selector 'a', text: 'ご褒美に招待する'
     end
 
     within("div##{dom_id(@goal_in_progress)}") do
@@ -49,7 +49,7 @@ class RewardsTest < ApplicationSystemTestCase
       assert_text reward_completed.description
 
       assert_no_selector 'a', text: '編集'
-      assert_no_selector 'a', text: 'このご褒美に招待する'
+      assert_no_selector 'a', text: 'ご褒美に招待する'
     end
 
     within("div##{dom_id(goal_completed)}") do
@@ -137,8 +137,8 @@ class RewardsTest < ApplicationSystemTestCase
     visit reward_path(@reward_in_progress)
 
     within('#reward') do
-      assert_selector 'a', text: 'このご褒美に招待する'
-      click_link_or_button 'このご褒美に招待する'
+      assert_selector 'a', text: 'ご褒美に招待する'
+      click_link_or_button 'ご褒美に招待する'
     end
 
     within('.modal-title') { assert_text 'ご褒美へ友人・家族を招待' }
@@ -187,8 +187,8 @@ class RewardsTest < ApplicationSystemTestCase
     visit reward_path(invited_reward)
 
     within('#reward') do
-      assert_selector 'a', text: 'このご褒美に招待する'
-      click_link_or_button 'このご褒美に招待する'
+      assert_selector 'a', text: 'ご褒美に招待する'
+      click_link_or_button 'ご褒美に招待する'
     end
 
     within('.modal-body') do
@@ -216,8 +216,8 @@ class RewardsTest < ApplicationSystemTestCase
     visit reward_path(invited_reward)
 
     within('#reward') do
-      assert_selector 'a', text: 'このご褒美に招待する'
-      click_link_or_button 'このご褒美に招待する'
+      assert_selector 'a', text: 'ご褒美に招待する'
+      click_link_or_button 'ご褒美に招待する'
     end
 
     within('.modal-body') do

--- a/test/system/reward_test.rb
+++ b/test/system/reward_test.rb
@@ -21,7 +21,7 @@ class RewardsTest < ApplicationSystemTestCase
       assert_text @reward_in_progress.description
 
       assert_selector 'a', text: '編集'
-      assert_selector 'a', text: '招待'
+      assert_selector 'a', text: 'このご褒美に招待する'
     end
 
     within("div##{dom_id(@goal_in_progress)}") do
@@ -49,7 +49,7 @@ class RewardsTest < ApplicationSystemTestCase
       assert_text reward_completed.description
 
       assert_no_selector 'a', text: '編集'
-      assert_no_selector 'a', text: '招待'
+      assert_no_selector 'a', text: 'このご褒美に招待する'
     end
 
     within("div##{dom_id(goal_completed)}") do
@@ -137,8 +137,8 @@ class RewardsTest < ApplicationSystemTestCase
     visit reward_path(@reward_in_progress)
 
     within('#reward') do
-      assert_selector 'a', text: '招待'
-      click_link_or_button '招待'
+      assert_selector 'a', text: 'このご褒美に招待する'
+      click_link_or_button 'このご褒美に招待する'
     end
 
     within('.modal-title') { assert_text 'ご褒美へ友人・家族を招待' }
@@ -187,8 +187,8 @@ class RewardsTest < ApplicationSystemTestCase
     visit reward_path(invited_reward)
 
     within('#reward') do
-      assert_selector 'a', text: '招待'
-      click_link_or_button '招待'
+      assert_selector 'a', text: 'このご褒美に招待する'
+      click_link_or_button 'このご褒美に招待する'
     end
 
     within('.modal-body') do
@@ -216,8 +216,8 @@ class RewardsTest < ApplicationSystemTestCase
     visit reward_path(invited_reward)
 
     within('#reward') do
-      assert_selector 'a', text: '招待'
-      click_link_or_button '招待'
+      assert_selector 'a', text: 'このご褒美に招待する'
+      click_link_or_button 'このご褒美に招待する'
     end
 
     within('.modal-body') do


### PR DESCRIPTION
## issue
https://github.com/SuzukiShuntarou/GifTreat/issues/222

## 概要
- 進捗率の取消ボタンを『キャンセル』という文言に修正し、目立たない灰色のリンクにした。
- 『削除』リンクの位置を変更しつつ文字を小さくし、元の場所に『目標一覧に戻る』リンクを追加した。
- 『ご褒美』枠内の配置とボタンを変更した
  -  『場所・ご褒美』『開催日』『招待ボタン・編集ボタン』の順番で配置
  - 『招待ボタン・編集ボタン』について招待ボタンを目立つように変更
- ご褒美と目標の横幅を一定にした（入力内容で横幅が変更しないようにした）
- 『候補日』のフォーマットを変更した（YYYY年MM月DD日(A)）