### PR TITLE
ご褒美の編集画面についてデザインレビューを元に修正した

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -27,7 +27,7 @@
     font-size: 16px;
   }
   .modal-dialog {
-    max-width: 80%;
+    max-width: 70%;
     margin: 1rem auto;
   }
 }
@@ -37,7 +37,7 @@
     font-size: 16px;
   }
   .modal-dialog {
-    max-width: 50rem;
+    max-width: 30rem;
     margin: 2rem auto;
   }
 }

--- a/app/views/application/_modal.html.erb
+++ b/app/views/application/_modal.html.erb
@@ -3,7 +3,7 @@
     <div class="modal-dialog modal-lg">
       <div class="modal-content modal-bg-color">
         <div class="modal-header">
-          <h3 class="modal-title"><%= title%></h3>
+          <h3 class="modal-title main-color"><%= title %></h3>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body px-3 py-2">

--- a/app/views/rewards/_form.html.erb
+++ b/app/views/rewards/_form.html.erb
@@ -1,21 +1,11 @@
 <%= turbo_frame_tag reward do %>
   <%= bootstrap_form_with(model: reward, label_errors: true, data: { action: "turbo:submit-end->modal#close" }) do |form| %>
-    <div class="d-flex justify-content-start">
-      <div class="d-flex align-items-center me-2">
-        <%= form.date_field :completion_date, class: 'rounded', append: 'に' %>
-      </div>
-      <div class="d-flex flex-grow-1 align-items-center">
-        <div class="flex-grow-1 me-2">
-          <%= form.text_area :location, class: 'rounded', append: 'で' %>
-        </div>
-      </div>
-    </div>
-    <div class="d-flex flex-grow-1 align-items-center">
-      <div class="flex-grow-1 me-2">
+    <div class="d-flex flex-column align-items-center">
+      <div class="w-100">
+        <%= form.date_field :completion_date, class: 'rounded'%>
+        <%= form.text_area :location, class: 'rounded', append: 'で' %>
         <%= form.text_area :description, class: 'rounded', append: 'する' %>
       </div>
-    </div>
-    <div class="d-flex justify-content-center">
       <%= form.submit "更新", class: "btn btn-outline-primary fs-5", style: "width: 10rem" %>
     </div>
   <% end %>


### PR DESCRIPTION
## issue
https://github.com/SuzukiShuntarou/GifTreat/issues/222

## 概要
- ご褒美の編集モーダルの表示の配置を詳細画面と同様に縦並びに変更した
- モーダルウインドウのタイトルの色を他ページのタイトルの色と同じ赤色に変更した
- モーダルウインドウのサイズを調整した