### PR TITLE
新規登録画面と詳細画面のborderに追加していたshadow-smを削除した

### DIFF
--- a/app/views/rewards/new.html.erb
+++ b/app/views/rewards/new.html.erb
@@ -6,7 +6,7 @@
   <%= bootstrap_form_with(model: @reward, label_errors: true) do |form| %>
     <section>
       <h3 class="border border-secondary-subtle rounded-top text-center main-color py-2 mt-1 mb-0">ご褒美</h3>
-      <div class="d-flex flex-column border border-secondary-subtle border-top-0 rounded-bottom shadow-sm mb-3 px-2 py-3">
+      <div class="d-flex flex-column border border-secondary-subtle border-top-0 rounded-bottom mb-3 px-2 py-3">
         <%= form.date_field :completion_date,
             class: 'form-control rounded w-75',
             help: 'ご褒美を受け取る日を入力して下さい。'
@@ -27,7 +27,7 @@
     </section>
     <section>
       <h3 class="border border-secondary-subtle rounded-top text-center main-color py-2 mt-1 mb-0">目標</h3>
-      <div class="border border-secondary-subtle border-top-0 rounded-bottom shadow-sm mb-2 px-2 py-3">
+      <div class="border border-secondary-subtle border-top-0 rounded-bottom mb-2 px-2 py-3">
         <div class="d-flex flex-column">
           <%= form.fields_for :goals do |goal_form| %>
             <%= goal_form.text_area :description,

--- a/app/views/rewards/show.html.erb
+++ b/app/views/rewards/show.html.erb
@@ -5,7 +5,7 @@
 <div class="d-flex flex-column align-items-center my-2 px-2">
   <section style="width: 22rem;">
     <h3 class="border border-secondary-subtle rounded-top text-center main-color py-2 mt-1 mb-0">ご褒美</h3>
-    <div class="flex-column border border-secondary-subtle border-top-0 rounded-bottom shadow-sm mb-3 py-3">
+    <div class="flex-column border border-secondary-subtle border-top-0 rounded-bottom mb-3 py-3">
       <div id='reward'>
         <%= render @reward %>
       </div>
@@ -18,7 +18,7 @@
           <h3 class="border border-secondary-subtle rounded-top text-center main-color py-2 mt-1 mb-0">
             <%= "#{goal.user.name}の目標" %>
           </h3>
-          <div class="d-flex flex-column border border-secondary-subtle border-top-0 rounded-bottom shadow-sm mb-2 px-2 py-3" style="min-height: 30rem;">
+          <div class="d-flex flex-column border border-secondary-subtle border-top-0 rounded-bottom mb-2 px-2 py-3" style="min-height: 30rem;">
             <div id="<%= dom_id(goal) %>" class="flex-grow-1">
               <%= render 'goals/goal', goal: goal %>
             </div>


### PR DESCRIPTION
## issue
- https://github.com/SuzukiShuntarou/GifTreat/issues/247
   - デザインレビューで指摘あった箇所の修正。
## 概要
- `border`に追加した`shadow-sm`を削除する。