### PR TITLE
パスワード再設定リンクの文言を修正した

### DIFF
--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -60,7 +60,7 @@ ja:
         message: パスワードが再設定されました。
         subject: パスワードの変更について
       reset_password_instructions:
-        action: パスワード再設定
+        action: パスワードの再設定はこちらから
         greeting: "%{recipient}様"
         instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
         instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。


### PR DESCRIPTION
## issue
- https://github.com/SuzukiShuntarou/GifTreat/issues/246

## 概要
- パスワード再設定のリンクについて『パスワード再設定』から『パスワードの再設定はこちらから』へ変更した。

## 変更後
![image](https://github.com/user-attachments/assets/170ffb59-5f1e-4213-a4ad-f75ba67195b1)
